### PR TITLE
reset INITIAL_STATE of guesses

### DIFF
--- a/src/redux/guesses.js
+++ b/src/redux/guesses.js
@@ -23,7 +23,7 @@ export const removeLetter = (rowIndex) => ({
   type: REMOVE_LETTER,
   rowIndex,
 });
-const INITIAL_STATE = ['abcde', 'abcde', 'abcde', 'abcde', 'abcde', 'abcde'];
+const INITIAL_STATE = ['', '', '', '', '', ''];
 
 export default function guessesReducer(guesses = INITIAL_STATE, action) {
   switch (action.type) {


### PR DESCRIPTION
Fix `INITIAL_STATE `of `guesses` redux; was using placeholders for css wireframing but forgot to revert.