### PR TITLE
resolves gh-20; remove react strict mode

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Board from './Board';
 import VirtualKeyboard from './VirtualKeyboard';
 import { connect } from 'react-redux';
 import { addLetter, removeLetter } from '../redux/guesses';
 import { updateRowIndex } from '../redux/rowIndex';
 import {
+  checkGameStatus,
   checkSolution,
   checkValidLength,
   checkValidWord,
@@ -12,16 +13,28 @@ import {
   keyEvaluator,
 } from './utils/validator';
 import NavBar from './NavBar';
+import { STATUS, updateStatus } from '../redux/status';
+import { setSolution } from '../redux/solution';
 
 export const Game = (props) => {
   const [boardEvaluations, setBoardEvaluations] = useState([]);
   const [keyEvaluations, setKeyEvaluations] = useState({});
+  const { setSolution } = props;
+
+  useEffect(() => {
+    setSolution();
+  }, [setSolution]);
+
+  useEffect(() => {
+    checkGameStatus(props.status);
+  }, [props.status]);
+
   const guess = props.guesses[props.rowIndex];
   const rowIndex = props.rowIndex;
 
   const handleInput = (key) => {
     const re = /[a-z]/i;
-    if (rowIndex < 6) {
+    if (props.status === STATUS.IN_PROGRESS) {
       if ((key === 'Backspace' || key === 'Delete') && guess.length > 0) {
         props.removeLetter(rowIndex);
       } else if (re.test(key) && key.length === 1 && guess.length < 5) {
@@ -34,31 +47,33 @@ export const Game = (props) => {
   };
 
   // TODO: ADD CASES FOR END GAME STATE
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const validLength = checkValidLength(guess);
     const validWord = checkValidWord(guess);
 
-    if (!validLength) {
-      alert(`Not enough letters`);
-    } else if (!validWord) {
-      alert('Not in word list');
-    } else {
-      alert(`Submitting word ${guess}`);
-      const rowEvaluation = checkSolution(guess);
-      const updatedKeyEvaluations = keyEvaluator(keyEvaluations, guess);
+    if (props.status === STATUS.IN_PROGRESS) {
+      if (!validLength) {
+        alert(`Not enough letters`);
+      } else if (!validWord) {
+        alert('Not in word list');
+      } else {
+        const rowEvaluation = checkSolution(guess);
+        const updatedKeyEvaluations = keyEvaluator(keyEvaluations, guess);
 
-      setBoardEvaluations([...boardEvaluations, rowEvaluation]);
-      setKeyEvaluations(updatedKeyEvaluations);
+        setBoardEvaluations([...boardEvaluations, rowEvaluation]);
+        setKeyEvaluations(updatedKeyEvaluations);
 
-      if (rowEvaluation.every(isCorrect)) {
-        alert(`WINNER WINNER`);
-        return;
-      }
+        // END GAME EDGE CASES
+        // All letters match, or you've reached your last guess
+        if (rowEvaluation.every(isCorrect)) {
+          props.updateStatus(STATUS.WIN);
+          return;
+        } else if (rowIndex === 5) {
+          props.updateStatus(STATUS.FAIL);
+          return;
+        }
 
-      props.updateRowIndex();
-
-      if (rowIndex === 6) {
-        alert('Ran out of guesses; game over');
+        props.updateRowIndex();
       }
     }
   };
@@ -78,12 +93,16 @@ export const Game = (props) => {
 const mapState = (state) => ({
   guesses: state.guesses,
   rowIndex: state.rowIndex,
+  status: state.status,
+  solution: state.solution,
 });
 
 const mapDispatch = (dispatch) => ({
+  setSolution: () => dispatch(setSolution()),
   addLetter: (letter, rowIndex) => dispatch(addLetter(letter, rowIndex)),
   removeLetter: (rowIndex) => dispatch(removeLetter(rowIndex)),
   updateRowIndex: () => dispatch(updateRowIndex()),
+  updateStatus: (status) => dispatch(updateStatus(status)),
 });
 
 export default connect(mapState, mapDispatch)(Game);

--- a/src/components/Row.js
+++ b/src/components/Row.js
@@ -14,7 +14,12 @@ export const Row = (props) => {
   return (
     <div className="grid grid-cols-5 gap-1.5">
       {word.split('').map((letter, idx) => (
-        <Tile key={idx} letter={letter} tileEvaluation={rowEvaluation[idx]} />
+        <Tile
+          key={idx}
+          letter={letter}
+          idx={idx}
+          tileEvaluation={rowEvaluation[idx]}
+        />
       ))}
     </div>
   );

--- a/src/components/utils/validator.js
+++ b/src/components/utils/validator.js
@@ -1,5 +1,6 @@
 import words from './words';
 import store from '../../store';
+import { STATUS } from '../../redux/status';
 
 export const EVALUATION = {
   CORRECT: 'correct',
@@ -44,9 +45,6 @@ export const colorEvaluator = (evaluation, typeEvaluator) => {
   }
 };
 
-export const isCorrect = (currentLetter) =>
-  currentLetter === EVALUATION.CORRECT;
-
 export const keyEvaluator = (keyEvalObj, guess) => {
   const evaluation = checkSolution(guess);
   for (let i = 0; i < guess.length; i++) {
@@ -69,4 +67,15 @@ export const keyEvaluator = (keyEvalObj, guess) => {
   }
 
   return keyEvalObj;
+};
+
+export const isCorrect = (currentLetter) =>
+  currentLetter === EVALUATION.CORRECT;
+
+export const checkGameStatus = (status) => {
+  if (status === STATUS.WIN) {
+    alert('WIN');
+  } else if (status === STATUS.FAIL) {
+    alert('GAME OVER');
+  }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,11 @@ import store from './store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>
+  // <React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
+  // </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -2,11 +2,13 @@ import { combineReducers } from 'redux';
 import guessesReducer from './guesses';
 import rowIndexReducer from './rowIndex';
 import { solutionReducer } from './solution';
+import { statusReducer } from './status';
 
 const appReducer = combineReducers({
   guesses: guessesReducer,
   rowIndex: rowIndexReducer,
   solution: solutionReducer,
+  status: statusReducer,
 });
 
 export default appReducer;

--- a/src/redux/solution.js
+++ b/src/redux/solution.js
@@ -1,11 +1,18 @@
+import words from '../components/utils/words';
+
 const SET_SOLUTION = 'SET_SOLUTION';
 
-export const setSolution = (solution) => ({
-  type: SET_SOLUTION,
-  solution,
-});
+export const setSolution = () => {
+  const solution = words[Math.floor(Math.random() * words.length)];
 
-const INITIAL_STATE = 'words';
+  return {
+    type: SET_SOLUTION,
+    solution,
+  };
+};
+
+const INITIAL_STATE = '';
+
 export const solutionReducer = (solution = INITIAL_STATE, action) => {
   switch (action.type) {
     case SET_SOLUTION:

--- a/src/redux/status.js
+++ b/src/redux/status.js
@@ -1,0 +1,23 @@
+const UPDATE_STATUS = 'UPDATE_STATUS';
+
+export const updateStatus = (status) => ({
+  type: UPDATE_STATUS,
+  status,
+});
+
+export const STATUS = {
+  IN_PROGRESS: 'IN_PROGRESS',
+  FAIL: 'FAIL',
+  WIN: 'WIN',
+};
+
+const INITIAL_STATE = 'IN_PROGRESS';
+
+export const statusReducer = (status = INITIAL_STATE, action) => {
+  switch (action.type) {
+    case UPDATE_STATUS:
+      return action.status;
+    default:
+      return status;
+  }
+};


### PR DESCRIPTION
- Added game state mechanism for end game edge cases
- Added validator `checkGameStatus`
- Aditionally, this PR resolves gh-24 with a basic fetch mechanism to grab a random word upon load of game as the solution, using `SET_SOLUTION`/`setSolution`
  - Note: `dev` environment was previously firing `SET_SOLUTION` twice, even in useEffect with correct dependencies. This is due to `<React.StrictMode>`. Took a bit to debug this, but it is a non-issue. Commented out `<React.StrictMode>` temporarily to ensure the expected effect was occuring, but as its a `dev `feature, should not have an impact on `prod`.
 
 More information regarding this can be found in the Article [How to Upgrade to React 18 > Other Notable Changes > React](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#react)
> When you use Strict Mode, React renders each component twice to help you find unexpected side effects.