### PR TITLE
Fix tile and key evaluations on load and submits

### DIFF
--- a/src/components/Game.js
+++ b/src/components/Game.js
@@ -27,6 +27,9 @@ export const Game = (props) => {
 
   const { setSolution, loadGame } = props;
 
+  const guess = props.guesses[props.rowIndex];
+  const rowIndex = props.rowIndex;
+
   useEffect(() => {
     const handleResize = () => {
       document.documentElement.style.setProperty(
@@ -49,8 +52,20 @@ export const Game = (props) => {
     } else {
       const gameState = JSON.parse(localStorageState);
       loadGame(gameState);
+      const localStorageEvaluations = gameState.game.guesses
+        .filter((guess) => guess !== '')
+        .map((guess) => checkSolution(guess));
+      const localStorageKeyEvaluations = {};
+
+      gameState.game.guesses.forEach((guess) =>
+        keyEvaluator(localStorageKeyEvaluations, guess)
+      );
+
+      setBoardEvaluations([...localStorageEvaluations]);
+      setKeyEvaluations({ ...localStorageKeyEvaluations });
     }
-  }, [setSolution, loadGame]);
+    return () => {};
+  }, [loadGame, setSolution, setBoardEvaluations, setKeyEvaluations]);
 
   useEffect(() => {
     checkGameStatus(props.status, [setToast, setShowToast], props.solution);
@@ -67,9 +82,6 @@ export const Game = (props) => {
     }, 2000);
     return () => clearInterval(interval);
   }, [toast, showToast]);
-
-  const guess = props.guesses[props.rowIndex];
-  const rowIndex = props.rowIndex;
 
   const handleInput = (key) => {
     const re = /[a-z]/i;
@@ -98,8 +110,8 @@ export const Game = (props) => {
         setShowToast(true);
       } else {
         const rowEvaluation = checkSolution(guess);
+        console.log(boardEvaluations);
         const updatedKeyEvaluations = keyEvaluator(keyEvaluations, guess);
-
         setBoardEvaluations([...boardEvaluations, rowEvaluation]);
         setKeyEvaluations(updatedKeyEvaluations);
 
@@ -130,7 +142,7 @@ export const Game = (props) => {
     setKeyEvaluations({});
     props.newGame();
     props.setSolution();
-    localStorage.setItem('rewordle-state', JSON.stringify(props.state));
+    setLocalStorage();
   };
 
   return (


### PR DESCRIPTION
Issue tracks from previous commit, which added localState persistence.
This resolve gh-44; with proper evaluations for keys and tiles loading upon continuing game (`LOAD_GAME` from `localStorage.getItem('rewordle-state')` and properly evaluates all subsequent row submissions.
